### PR TITLE
Adapt Dockerfile to build a FIPS-compliant rabbitmq-cluster-operator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
+
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.20 as builder
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.20 as builder
 
 WORKDIR /workspace
+
+USER root
 
 # Dependencies are cached unless we change go.mod or go.sum
 COPY go.mod go.mod
@@ -20,26 +23,18 @@ ARG TARGETOS
 ARG TARGETARCH
 ENV GOOS $TARGETOS
 ENV GOARCH $TARGETARCH
-RUN CGO_ENABLED=0 GO111MODULE=on go build -a -tags timetzdata -o manager main.go
+RUN CGO_ENABLED=1 GO111MODULE=on go build -a -tags 'strictfipsruntime timetzdata' -o manager main.go
 
-# ---------------------------------------
-FROM alpine:latest as etc-builder
-
-RUN echo "rabbitmq-cluster-operator:x:1000:" > /etc/group && \
-    echo "rabbitmq-cluster-operator:x:1000:1000::/home/rabbitmq-cluster-operator:/usr/sbin/nologin" > /etc/passwd
-
-RUN apk add -U --no-cache ca-certificates
-
-# ---------------------------------------
-FROM scratch
+# ---
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 ARG GIT_COMMIT
 LABEL GitCommit=$GIT_COMMIT
 
 WORKDIR /
 COPY --from=builder /workspace/manager .
-COPY --from=etc-builder /etc/passwd /etc/group /etc/
-COPY --from=etc-builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+RUN echo "rabbitmq-cluster-operator:x:1000:" > /etc/group && \
+    echo "rabbitmq-cluster-operator:x:1000:1000::/home/rabbitmq-cluster-operator:/usr/sbin/nologin" > /etc/passwd
 
 USER 1000:1000
 


### PR DESCRIPTION
This commit modifies the Dockerfile to have the rabbitmq-cluster-operator to be built from ubi9 go-toolset and ubi-minimal images so to have the necessary dependencies to be FIPS compliant.

It also squashes the build steps by removing the intermediate step where we create the respective user/group.

This closes #

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed

## Summary Of Changes

## Additional Context

## Local Testing

Please ensure you run the unit, integration and system tests before approving the PR.

To run the unit and integration tests:

```
$ make unit-tests integration-tests
```

You will need to target a k8s cluster and have the operator deployed for running the system tests.

For example, for a Kubernetes context named `dev-bunny`:
```
$ kubectx dev-bunny
$ make destroy deploy-dev
# wait for operator to be deployed
$ make system-tests
``` 
