### PR TITLE
Set FIPS flag in operator csv

### DIFF
--- a/.prow_ci.env
+++ b/.prow_ci.env
@@ -1,0 +1,2 @@
+export USE_IMAGE_DIGESTS=true
+export FAIL_FIPS_CHECK=true

--- a/config/manifests/bases/rabbitmq-cluster-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/rabbitmq-cluster-operator.clusterserviceversion.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
+    features.operators.openshift.io/fips-compliant: "true"
     operators.operatorframework.io/operator-type: non-standalone
   name: rabbitmq-cluster-operator.v0.0.1
   namespace: placeholder


### PR DESCRIPTION
This forked rabbitmq operator from has already been modified [1] to support FIPS-compliant container image build.

Add a FIPS-compliant flag in the fork's csv as well, to match other operators in the openstack-k8s-operators git namespace.

[1] 7bc6842d4c6de588919de9fd42ddb54af00fcb62

Jira: OSPRH-7056
