### PR TITLE
Add sample to use in operators kuttl tests

### DIFF
--- a/config/samples/kuttl/rabbitmq_v1_beta1_rabbitmqcluster_for_kuttl_tests.yaml
+++ b/config/samples/kuttl/rabbitmq_v1_beta1_rabbitmqcluster_for_kuttl_tests.yaml
@@ -1,0 +1,48 @@
+#!/bin/bash
+#
+# Copyright 2024 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may                                                                                                                 
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#   
+#      http://www.apache.org/licenses/LICENSE-2.0
+#   
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+apiVersion: rabbitmq.com/v1beta1
+kind: RabbitmqCluster
+metadata:
+  name: rabbitmq
+spec:
+  override:
+    statefulSet:
+      spec:
+        template:
+          spec:
+            containers:
+            - args:
+              - /usr/lib/rabbitmq/bin/rabbitmq-server
+              env:
+              - name: RABBITMQ_UPGRADE_LOG
+                value: /var/lib/rabbitmq/rabbitmq_upgrade.log
+              - name: HOME
+                value: /var/lib/rabbitmq
+              - name: PATH
+                value: /usr/lib/rabbitmq/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+              name: rabbitmq
+              resources: {}
+            initContainers:
+            - name: setup-container
+              resources: {}
+              securityContext: {}
+            securityContext: {}
+  persistance:
+    storageClassName: local-storage
+  rabbitmq:
+    additionalConfig: log.console = true
+  replicas: 1


### PR DESCRIPTION
Add a sample that can be used in other operators kuttl test, which deploy the operators individually. This sample has been tested and works with the rabbitmq image from
quay.io/podified-antelope-centos9/openstack-rabbitmq repository.

cherry-pick of https://github.com/openstack-k8s-operators/rabbitmq-cluster-operator/pull/3